### PR TITLE
[V1][CUDA Graph] Fix attention metadata tensor sizes for padded batches

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -40,13 +40,16 @@ class BatchDescriptor(NamedTuple):
     False can also be used for an uniform decode batch to dispatch to the 
     cudagraph supporting non-uniform batches.
     """
+    num_reqs: Optional[int] = None
 
     @property
     def non_uniform(self) -> "BatchDescriptor":
         """
         Return a non-uniform version of current batch descriptor.
         """
-        return BatchDescriptor(self.num_tokens, uniform_decode=False)
+        return BatchDescriptor(self.num_tokens,
+                               uniform_decode=False,
+                               num_reqs=self.num_reqs)
 
 
 def _compute_chunked_local_num_tokens(num_tokens_across_dp_cpu: list[int],

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from math import ceil
 from typing import Optional
+
+from typing_extensions import TypeAlias
 
 from vllm.config import CompilationLevel, CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+CUDAGraphKey: TypeAlias = tuple[int, bool]
 
 
 class CudagraphDispatcher:
@@ -34,10 +38,11 @@ class CudagraphDispatcher:
         self.cudagraph_mode = self.compilation_config.cudagraph_mode
 
         # Dict to store valid cudagraph dispatching keys.
-        self.cudagraph_keys: dict[CUDAGraphMode, set[BatchDescriptor]] = {
-            CUDAGraphMode.PIECEWISE: set(),
-            CUDAGraphMode.FULL: set(),
-        }
+        self.cudagraph_keys: dict[CUDAGraphMode,
+                                  dict[CUDAGraphKey, BatchDescriptor]] = {
+                                      CUDAGraphMode.PIECEWISE: {},
+                                      CUDAGraphMode.FULL: {},
+                                  }
 
         assert not self.cudagraph_mode.requires_piecewise_compilation() or \
             (self.compilation_config.level == CompilationLevel.PIECEWISE and
@@ -54,7 +59,8 @@ class CudagraphDispatcher:
                           batch_descriptor: BatchDescriptor):
         assert runtime_mode in [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL], \
             f"Invalid cudagraph runtime mode: {runtime_mode}"
-        self.cudagraph_keys[runtime_mode].add(batch_descriptor)
+        key = (batch_descriptor.num_tokens, batch_descriptor.uniform_decode)
+        self.cudagraph_keys[runtime_mode][key] = batch_descriptor
 
     def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode,
                                   uniform_decode_query_len: int):
@@ -67,11 +73,25 @@ class CudagraphDispatcher:
         # trigger capturing/replaying the piecewise cudagraphs depending on
         # CompilationConfig.cudagraph_mode. In addition, if we allow lazy
         # capturing in future PR, some keys may never be triggered.
-        if cudagraph_mode.mixed_mode() != CUDAGraphMode.NONE:
+        # Add mixed mode keys with proper num_reqs calculation
+        if cudagraph_mode.mixed_mode() == CUDAGraphMode.PIECEWISE:
             for bs in self.compilation_config.cudagraph_capture_sizes:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, False)
                 self.add_cudagraph_key(
-                    cudagraph_mode.mixed_mode(),
-                    BatchDescriptor(num_tokens=bs, uniform_decode=False))
+                    CUDAGraphMode.PIECEWISE,
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=False,
+                                    num_reqs=num_reqs))
+        elif cudagraph_mode.mixed_mode() == CUDAGraphMode.FULL:
+            for bs in self.compilation_config.cudagraph_capture_sizes:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, False)
+                self.add_cudagraph_key(
+                    CUDAGraphMode.FULL,
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=False,
+                                    num_reqs=num_reqs))
 
         # if decode cudagraph mode is FULL, and we don't already have mixed
         # mode full cudagraphs then add them here.
@@ -84,10 +104,32 @@ class CudagraphDispatcher:
                 if x <= max_num_tokens and x >= uniform_decode_query_len
             ]
             for bs in cudagraph_capture_sizes_for_decode:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, True)
                 self.add_cudagraph_key(
                     CUDAGraphMode.FULL,
-                    BatchDescriptor(num_tokens=bs, uniform_decode=True))
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=True,
+                                    num_reqs=num_reqs))
+
         self.keys_initialized = True
+
+    def calculate_num_reqs_for_tokens(self, num_tokens: int,
+                                      uniform_decode_query_len: int,
+                                      uniform_decode: bool) -> int:
+        max_num_seqs = self.vllm_config.scheduler_config.max_num_seqs
+
+        if uniform_decode:
+            num_reqs = ceil(num_tokens / uniform_decode_query_len)
+            return min(num_reqs, max_num_seqs)
+        else:
+            return min(num_tokens, max_num_seqs)
+
+    def _is_compatible(self, batch_descriptor: BatchDescriptor,
+                       candidate: BatchDescriptor) -> bool:
+        """Check if candidate cudagraph can handle the batch request."""
+        return (batch_descriptor.num_reqs is None or candidate.num_reqs is None
+                or candidate.num_reqs >= batch_descriptor.num_reqs)
 
     def dispatch(
         self, batch_descriptor: BatchDescriptor
@@ -103,19 +145,17 @@ class CudagraphDispatcher:
                                 "initialized. No cudagraph will be used.")
             return CUDAGraphMode.NONE, None
 
-        # check if key exists for full cudagraph
-        if batch_descriptor in self.cudagraph_keys[CUDAGraphMode.FULL]:
-            return CUDAGraphMode.FULL, batch_descriptor
+        num_tokens, uniform_decode = (batch_descriptor.num_tokens,
+                                      batch_descriptor.uniform_decode)
 
-        # otherwise, check if non-uniform key exists
-        non_uniform_key = batch_descriptor.non_uniform
-        if non_uniform_key in self.cudagraph_keys[CUDAGraphMode.FULL]:
-            return CUDAGraphMode.FULL, non_uniform_key
+        candidates = [(CUDAGraphMode.FULL, (num_tokens, uniform_decode))]
+        if uniform_decode:
+            candidates.append((CUDAGraphMode.FULL, (num_tokens, False)))
+        candidates.append((CUDAGraphMode.PIECEWISE, (num_tokens, False)))
 
-        # also check if non-uniform key exists for more "general"
-        # piecewise cudagraph
-        if non_uniform_key in self.cudagraph_keys[CUDAGraphMode.PIECEWISE]:
-            return CUDAGraphMode.PIECEWISE, non_uniform_key
+        for mode, key in candidates:
+            candidate = self.cudagraph_keys[mode].get(key)
+            if candidate and self._is_compatible(batch_descriptor, candidate):
+                return mode, candidate
 
-        # finally, just return no cudagraphs
         return CUDAGraphMode.NONE, None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -905,7 +905,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return encoder_seq_lens
 
     def _prepare_inputs(
-        self, scheduler_output: "SchedulerOutput"
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_input_tokens: Optional[int] = None,
+        num_reqs: Optional[int] = None
     ) -> tuple[PerLayerAttnMetadata, torch.Tensor,
                Optional[SpecDecodeMetadata], np.ndarray,
                Optional[CommonAttentionMetadata], int, Optional[UBatchSlices],
@@ -918,8 +921,14 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         total_num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         assert total_num_scheduled_tokens > 0
-        num_reqs = self.input_batch.num_reqs
+
+        if num_input_tokens is None:
+            num_input_tokens = total_num_scheduled_tokens
+        if num_reqs is None:
+            num_reqs = self.input_batch.num_reqs
         assert num_reqs > 0
+
+        actual_num_reqs = self.input_batch.num_reqs
 
         # OPTIMIZATION: Start copying the block table first.
         # This way, we can overlap the copy with the following CPU operations.
@@ -928,8 +937,13 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Get the number of scheduled tokens for each request.
         req_ids = self.input_batch.req_ids
         tokens = [scheduler_output.num_scheduled_tokens[i] for i in req_ids]
-        num_scheduled_tokens = np.array(tokens, dtype=np.int32)
-        max_num_scheduled_tokens = max(tokens)
+
+        if num_reqs > actual_num_reqs:
+            num_scheduled_tokens = np.zeros(num_reqs, dtype=np.int32)
+            num_scheduled_tokens[:actual_num_reqs] = tokens
+        else:
+            num_scheduled_tokens = np.array(tokens, dtype=np.int32)
+        max_num_scheduled_tokens = max(num_scheduled_tokens)
 
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
@@ -1040,7 +1054,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.input_batch.num_computed_tokens_cpu[:num_reqs] +
             num_scheduled_tokens)
         # Fill unused with 0 for full cuda graph mode.
-        self.seq_lens.np[num_reqs:].fill(0)
+        self.seq_lens.np[actual_num_reqs:].fill(0)
         self.seq_lens.copy_to_gpu()
         seq_lens = self.seq_lens.gpu[:num_reqs]
         max_seq_len = self.seq_lens.np[:num_reqs].max().item()
@@ -1138,7 +1152,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     device=self.device,
                 )
                 slot_mapping = torch.zeros(
-                    (total_num_scheduled_tokens, ),
+                    (num_input_tokens, ),
                     dtype=torch.int64,
                     device=self.device,
                 )
@@ -1146,8 +1160,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 blk_table = self.input_batch.block_table[kv_cache_group_id]
                 blk_table_tensor = blk_table.get_device_tensor(num_reqs)
-                slot_mapping = blk_table.slot_mapping.gpu[:
-                                                          total_num_scheduled_tokens]
+                slot_mapping = blk_table.slot_mapping.gpu[:num_input_tokens]
 
                 # Fill unused with -1. Needed for reshape_and_cache in full cuda
                 # graph mode.
@@ -1164,7 +1177,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 seq_lens_cpu=seq_lens_cpu,
                 num_computed_tokens_cpu=num_computed_tokens_cpu,
                 num_reqs=num_reqs,
-                num_actual_tokens=total_num_scheduled_tokens,
+                num_actual_tokens=num_input_tokens,
                 max_query_len=max_num_scheduled_tokens,
                 max_seq_len=max_seq_len,
                 block_table_tensor=blk_table_tensor,
@@ -2146,14 +2159,44 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     " need prompt logprobs")
 
             if self.prepare_inputs_event is not None:
-                # Ensure prior step has finished with reused CPU tensors.
                 self.prepare_inputs_event.synchronize()
+
+            preliminary_num_input_tokens = self._get_num_input_tokens(
+                scheduler_output.total_num_scheduled_tokens)
+
+            # Detect uniform decode batches for CUDA graph optimization
+            is_pure_decode = (not scheduler_output.scheduled_new_reqs
+                              and scheduler_output.num_scheduled_tokens)
+            if is_pure_decode:
+                num_tokens_per_req = list(
+                    scheduler_output.num_scheduled_tokens.values())
+                uniform_decode = all(n == self.uniform_decode_query_len
+                                     for n in num_tokens_per_req)
+            else:
+                uniform_decode = False
+
+            batch_descriptor = BatchDescriptor(
+                num_tokens=preliminary_num_input_tokens,
+                uniform_decode=uniform_decode,
+                num_reqs=self.input_batch.num_reqs)
+            cudagraph_runtime_mode, padded_batch_descriptor = \
+                self.cudagraph_dispatcher.dispatch(batch_descriptor)
+
+            padded_num_input_tokens = (padded_batch_descriptor.num_tokens
+                                       if padded_batch_descriptor else
+                                       preliminary_num_input_tokens)
+            padded_num_reqs = (padded_batch_descriptor.num_reqs
+                               if padded_batch_descriptor else
+                               self.input_batch.num_reqs)
+
             try:
-                # Prepare the decoder inputs.
                 (attn_metadata, logits_indices, spec_decode_metadata,
                  num_scheduled_tokens_np, spec_decode_common_attn_metadata,
-                 max_query_len, ubatch_slices, num_tokens_after_padding
-                 ) = self._prepare_inputs(scheduler_output)
+                 max_query_len, ubatch_slices,
+                 num_tokens_after_padding) = self._prepare_inputs(
+                     scheduler_output,
+                     num_input_tokens=padded_num_input_tokens,
+                     num_reqs=padded_num_reqs)
 
             finally:
                 if self.prepare_inputs_event is not None:
@@ -2174,15 +2217,6 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if ubatch_slices is not None:
                 num_input_tokens = num_input_tokens // 2
 
-            uniform_decode = (max_query_len
-                              == self.uniform_decode_query_len) and (
-                                  num_scheduled_tokens
-                                  == self.input_batch.num_reqs * max_query_len)
-            batch_descriptor = BatchDescriptor(num_tokens=num_input_tokens,
-                                               uniform_decode=uniform_decode)
-            cudagraph_runtime_mode, batch_descriptor = \
-                self.cudagraph_dispatcher.dispatch(batch_descriptor)
-
         # Run the model.
         # Use persistent buffers for CUDA graphs.
         with (set_forward_context(
@@ -2191,7 +2225,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
-                batch_descriptor=batch_descriptor,
+                batch_descriptor=padded_batch_descriptor,
                 ubatch_slices=ubatch_slices,
         ), record_function_or_nullcontext("Forward"),
               self.maybe_get_kv_connector_output(scheduler_output) as
@@ -3039,11 +3073,16 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if cudagraph_runtime_mode == CUDAGraphMode.NONE:
                 batch_descriptor = None
             else:
-                # filter out the valid batch descriptor
+                num_reqs = (
+                    self.cudagraph_dispatcher.calculate_num_reqs_for_tokens(
+                        num_tokens, self.uniform_decode_query_len,
+                        uniform_decode))
+
                 _cg_mode, batch_descriptor = \
                     self.cudagraph_dispatcher.dispatch(
                         BatchDescriptor(num_tokens=num_tokens,
-                                        uniform_decode=uniform_decode))
+                                        uniform_decode=uniform_decode,
+                                        num_reqs=num_reqs))
                 # sanity check
                 assert cudagraph_runtime_mode == _cg_mode, (
                     f"Cudagraph runtime mode mismatch at dummy_run. "


### PR DESCRIPTION
Currently, cudagraph padding is applied after attention metadata is created, causing dimension mismatches between metadata and actual tensors. This leads to issues in attention backends like FlashMLA and FlashAttn.

This change moves the padding calculation before metadata construction and adds support for request-level padding in full cudagraph mode:

- Add num_reqs field to BatchDescriptor for request dimension tracking
- Calculate padding requirements before _prepare_inputs() call
- Support both token and request padding for full cudagraphs
- Only pad tokens for piecewise cudagraphs to avoid wasted computation
- Fix slot mapping padding to only fill padded region

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

