### PR TITLE
[V1][CUDA Graph] Fix attention metadata tensor sizes for padded batches

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -40,13 +40,16 @@ class BatchDescriptor(NamedTuple):
     False can also be used for an uniform decode batch to dispatch to the 
     cudagraph supporting non-uniform batches.
     """
+    num_reqs: Optional[int] = None
 
     @property
     def non_uniform(self) -> "BatchDescriptor":
         """
         Return a non-uniform version of current batch descriptor.
         """
-        return BatchDescriptor(self.num_tokens, uniform_decode=False)
+        return BatchDescriptor(self.num_tokens,
+                               uniform_decode=False,
+                               num_reqs=self.num_reqs)
 
 
 def _compute_chunked_local_num_tokens(num_tokens_across_dp_cpu: list[int],

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from math import ceil
 from typing import Optional
+
+from typing_extensions import TypeAlias
 
 from vllm.config import CompilationLevel, CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+CUDAGraphKey: TypeAlias = tuple[int, bool]
 
 
 class CudagraphDispatcher:
@@ -34,10 +38,11 @@ class CudagraphDispatcher:
         self.cudagraph_mode = self.compilation_config.cudagraph_mode
 
         # Dict to store valid cudagraph dispatching keys.
-        self.cudagraph_keys: dict[CUDAGraphMode, set[BatchDescriptor]] = {
-            CUDAGraphMode.PIECEWISE: set(),
-            CUDAGraphMode.FULL: set(),
-        }
+        self.cudagraph_keys: dict[CUDAGraphMode,
+                                  dict[CUDAGraphKey, BatchDescriptor]] = {
+                                      CUDAGraphMode.PIECEWISE: {},
+                                      CUDAGraphMode.FULL: {},
+                                  }
 
         assert not self.cudagraph_mode.requires_piecewise_compilation() or \
             (self.compilation_config.level == CompilationLevel.PIECEWISE and
@@ -54,7 +59,8 @@ class CudagraphDispatcher:
                           batch_descriptor: BatchDescriptor):
         assert runtime_mode in [CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL], \
             f"Invalid cudagraph runtime mode: {runtime_mode}"
-        self.cudagraph_keys[runtime_mode].add(batch_descriptor)
+        key = (batch_descriptor.num_tokens, batch_descriptor.uniform_decode)
+        self.cudagraph_keys[runtime_mode][key] = batch_descriptor
 
     def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode,
                                   uniform_decode_query_len: int):
@@ -67,11 +73,25 @@ class CudagraphDispatcher:
         # trigger capturing/replaying the piecewise cudagraphs depending on
         # CompilationConfig.cudagraph_mode. In addition, if we allow lazy
         # capturing in future PR, some keys may never be triggered.
-        if cudagraph_mode.mixed_mode() != CUDAGraphMode.NONE:
+        # Add mixed mode keys with proper num_reqs calculation
+        if cudagraph_mode.mixed_mode() == CUDAGraphMode.PIECEWISE:
             for bs in self.compilation_config.cudagraph_capture_sizes:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, False)
                 self.add_cudagraph_key(
-                    cudagraph_mode.mixed_mode(),
-                    BatchDescriptor(num_tokens=bs, uniform_decode=False))
+                    CUDAGraphMode.PIECEWISE,
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=False,
+                                    num_reqs=num_reqs))
+        elif cudagraph_mode.mixed_mode() == CUDAGraphMode.FULL:
+            for bs in self.compilation_config.cudagraph_capture_sizes:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, False)
+                self.add_cudagraph_key(
+                    CUDAGraphMode.FULL,
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=False,
+                                    num_reqs=num_reqs))
 
         # if decode cudagraph mode is FULL, and we don't already have mixed
         # mode full cudagraphs then add them here.
@@ -84,10 +104,35 @@ class CudagraphDispatcher:
                 if x <= max_num_tokens and x >= uniform_decode_query_len
             ]
             for bs in cudagraph_capture_sizes_for_decode:
+                num_reqs = self.calculate_num_reqs_for_tokens(
+                    bs, uniform_decode_query_len, True)
                 self.add_cudagraph_key(
                     CUDAGraphMode.FULL,
-                    BatchDescriptor(num_tokens=bs, uniform_decode=True))
+                    BatchDescriptor(num_tokens=bs,
+                                    uniform_decode=True,
+                                    num_reqs=num_reqs))
+
         self.keys_initialized = True
+
+    def calculate_num_reqs_for_tokens(self, num_tokens: int,
+                                      uniform_decode_query_len: int,
+                                      uniform_decode: bool) -> int:
+        max_num_seqs = self.vllm_config.scheduler_config.max_num_seqs
+
+        if uniform_decode:
+            num_reqs = ceil(num_tokens / uniform_decode_query_len)
+            return min(num_reqs, max_num_seqs)
+        else:
+            return min(num_tokens, max_num_seqs)
+
+    def _is_compatible(self, batch_descriptor: BatchDescriptor,
+                       candidate: BatchDescriptor) -> bool:
+        """Check if candidate cudagraph can handle the batch request."""
+        if candidate.num_reqs is None:
+            return True
+        if batch_descriptor.num_reqs is None:
+            return False
+        return candidate.num_reqs >= batch_descriptor.num_reqs
 
     def dispatch(
         self, batch_descriptor: BatchDescriptor
@@ -103,19 +148,17 @@ class CudagraphDispatcher:
                                 "initialized. No cudagraph will be used.")
             return CUDAGraphMode.NONE, None
 
-        # check if key exists for full cudagraph
-        if batch_descriptor in self.cudagraph_keys[CUDAGraphMode.FULL]:
-            return CUDAGraphMode.FULL, batch_descriptor
+        num_tokens, uniform_decode = (batch_descriptor.num_tokens,
+                                      batch_descriptor.uniform_decode)
 
-        # otherwise, check if non-uniform key exists
-        non_uniform_key = batch_descriptor.non_uniform
-        if non_uniform_key in self.cudagraph_keys[CUDAGraphMode.FULL]:
-            return CUDAGraphMode.FULL, non_uniform_key
+        candidates = [(CUDAGraphMode.FULL, (num_tokens, uniform_decode))]
+        if uniform_decode:
+            candidates.append((CUDAGraphMode.FULL, (num_tokens, False)))
+        candidates.append((CUDAGraphMode.PIECEWISE, (num_tokens, False)))
 
-        # also check if non-uniform key exists for more "general"
-        # piecewise cudagraph
-        if non_uniform_key in self.cudagraph_keys[CUDAGraphMode.PIECEWISE]:
-            return CUDAGraphMode.PIECEWISE, non_uniform_key
+        for mode, key in candidates:
+            candidate = self.cudagraph_keys[mode].get(key)
+            if candidate and self._is_compatible(batch_descriptor, candidate):
+                return mode, candidate
 
-        # finally, just return no cudagraphs
         return CUDAGraphMode.NONE, None


### PR DESCRIPTION
Currently, cudagraph padding is applied after attention metadata is created, causing dimension mismatches between metadata and actual tensors. This leads to issues in attention backends like FlashMLA and FlashAttn.

This change moves the padding calculation before metadata construction and adds support for request-level padding in full cudagraph mode:

- Add num_reqs field to BatchDescriptor for request dimension tracking
- Calculate padding requirements before _prepare_inputs() call
- Support both token and request padding for full cudagraphs
- Only pad tokens for piecewise cudagraphs to avoid wasted computation
- Fix slot mapping padding to only fill padded region

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

